### PR TITLE
call CheckPropUndo() on fixedupdate instead

### DIFF
--- a/Code/Player/PawnSystem/PlayerState.Cleanup.cs
+++ b/Code/Player/PawnSystem/PlayerState.Cleanup.cs
@@ -20,10 +20,13 @@ public partial class PlayerState : Component.INetworkListener
 		}
 	}
 
-	protected override void OnUpdate()
+	protected override void OnFixedUpdate()
 	{
 		CheckPropUndo();
-		
+	}
+
+	protected override void OnUpdate()
+	{
 		if ( IsConnected ) return;
 		if ( IsProxy ) return;
 

--- a/Code/Player/PawnSystem/PlayerState.Props.cs
+++ b/Code/Player/PawnSystem/PlayerState.Props.cs
@@ -4,7 +4,7 @@ public partial class PlayerState
 {
 	public List<Thing> SpawnedThings { get; private set; } = new();
 
-	private float undoPropHeldTimer = -2;
+	private float undoPropHeldTimer = -1;
 	private float undoPropRate = 1;
 
 	protected void CheckPropUndo()
@@ -12,12 +12,12 @@ public partial class PlayerState
 		if ( Input.Pressed( "undo" ) )
 		{
 			undoPropRate = 1;
-			undoPropHeldTimer = -2;
+			undoPropHeldTimer = -1;
 			HandlePropDestroyInitiation();
 		}
 		else if ( Input.Down( "undo" ) )
 		{
-			undoPropRate -= 0.0045f * Time.Delta;
+			undoPropRate -= 0.0045f;
 			undoPropHeldTimer += 0.04f;
 			if ( undoPropHeldTimer > undoPropRate )
 			{


### PR DESCRIPTION
Should mitigate accidentally activating chain undo, if issue still persists just decrease undoPropHeldTimer initial value 