### PR TITLE
view model packages now spawnable and other stuff

### DIFF
--- a/Code/GameMode/GameUtils.cs
+++ b/Code/GameMode/GameUtils.cs
@@ -163,4 +163,20 @@ public static partial class GameUtils
 
 		throw new Exception( "We should have returned an item already!" );
 	}
+
+	public static string getClosestString( List<string> stringsList, string stringToCompare )
+	{
+		var firstTest = stringsList
+		.FirstOrDefault( item => stringToCompare.Contains( item, StringComparison.OrdinalIgnoreCase ) );
+		if ( firstTest != null )
+		{
+			return firstTest;
+		}
+		var matches = stringsList.Select( item => stringToCompare.Count( c => item.Contains( c ) ) );
+
+		var closestMatch = stringsList.Zip( matches, ( str, count ) => new { String = str, Count = count } )
+									 .OrderByDescending( pair => pair.Count )
+									 .FirstOrDefault()?.String;
+		return closestMatch;
+	}
 }

--- a/Code/Player/PawnSystem/PlayerState.Props.cs
+++ b/Code/Player/PawnSystem/PlayerState.Props.cs
@@ -7,6 +7,15 @@ public partial class PlayerState
 	private float undoPropHeldTimer = -2;
 	private float undoPropRate = 1;
 
+	public void AddPropToList( GameObject gameObject )
+	{
+		PlayerState.Thing thing = new PlayerState.Thing
+		{
+			gameObjects = new List<GameObject> { gameObject }
+		};
+		SpawnedThings.Add( thing );
+	}
+
 	protected void CheckPropUndo()
 	{
 		if ( Input.Pressed( "undo" ) )


### PR DESCRIPTION
- View model packages are handled by spawning loaded weapons according to name instead
- Implemented AddPropToList() to simplify adding props wherever
- Small fix to ensure skinned props are spawned as props (yet fall through the floor)

PlayerInventory.cs now looks a bit messy and inconvenient, im fine with suggesting another way about this 

Current issues:
-Spawned(Dropped) weapons dont spawn relative to client's eye local rotation for some reason