### PR TITLE
Remove Unnecessary Validity Check from Chat.razor

### DIFF
--- a/Code/UI/Hud/Components/Chat/Chat.razor
+++ b/Code/UI/Hud/Components/Chat/Chat.razor
@@ -84,9 +84,6 @@
     {
         var e = Canvas.AddChild<ChatRow>();
 
-        var player = Player.FindLocalPlayer();
-        if (!player.IsValid()) return;
-
         if (playerId > 0)
             e.PlayerId = playerId;
 


### PR DESCRIPTION
This led to issue #110 which causes dead players to not see any messages, only blank boxes.
   I do not know the point of this player variable. I don't think it serves any purpose, nor do I think the validity check does, but I wouldn't mind being double checked on that front. In any case, I currently believe that these two lines do nothing of importance and only cause this bug.